### PR TITLE
Minor fixes

### DIFF
--- a/R/confusion.R
+++ b/R/confusion.R
@@ -12,6 +12,9 @@
 #'   frequencies of actual vs. predicted class with attributes `accuracy`
 #'   and `error` giving the overall rates of correct and incorrect prediction.
 #' @seealso [MASS::lda()], [MASS::qda()]
+#' 
+#' @importFrom insight get_response
+#' 
 #' @export
 #'
 #' @examples

--- a/R/plot_discrim.R
+++ b/R/plot_discrim.R
@@ -12,7 +12,7 @@
 # DONE: ✔️ Added `rev.axes` parameter for reversing discriminant axes
 # DONE: ✔️ Added `xlim`, `ylim` arguments to control axis limits; useful for plots in discrim space.
 #
-# TOTO: ❌ Fix mapping for stat_ellipse() when specifying `geom = "polygon"`
+# TODO: ❌ Fix mapping for stat_ellipse() when specifying `geom = "polygon"`
 # TODO: Create vignette detailing how to use more generally with ggplot
 
 #' Discriminant Analysis Decision Plot using ggplot.
@@ -26,7 +26,7 @@
 #' 
 #' In the case of discriminant analysis, the predicted values are class membership,
 #' so this can be visualized by mapping the categorical predicted class to discrete colors used as the background for the plot, or
-#' plotting the **contours** of predicted class membership as lines (for `[MASS::lda()]`) or qauadratic curves (for `[MASS::qda()]`) in the plot.
+#' plotting the **contours** of predicted class membership as lines (for `[MASS::lda()]`) or quadratic curves (for `[MASS::qda()]`) in the plot.
 #' The predicted class of any observation in the space of the variables displayed can also be rendered as colored **tiles** or **points**
 #' in the background of the plot.
 #' 

--- a/R/redundancy.R
+++ b/R/redundancy.R
@@ -33,7 +33,7 @@
 #' \item{Y.redun}{Total canonical redundancy for the Y variables} 
 #' \item{set.names}{names for the X and Y sets of variables}
 #' @author Michael Friendly
-#' @seealso \ [cancor()]
+#' @seealso [cancor()]
 #' @references 
 #' Muller K. E. (1981).
 #'Relationships between redundancy analysis, canonical correlation, and multivariate regression. 

--- a/R/reflect.R
+++ b/R/reflect.R
@@ -47,7 +47,7 @@
 #' X <- as.matrix(Rohwer[,6:10])  # the PA tests
 #' Y <- as.matrix(Rohwer[,3:5])   # the aptitude/ability variables
 #' Rohwer.can <- cancor(X, Y, set.names=c("PA", "Ability"))
-#' coef(Rohwer)
+#' coef(Rohwer.can)
 #' Rohwer.can |> reflect() |> coef()
 #'
 #' 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -15,7 +15,7 @@ c(
                      family = "Fox", role="aut")),
     year     = year,
     note     = note,
-    url      = "https://CRAN.R-project.org/package=heplots"
+    url      = "https://CRAN.R-project.org/package=candisc"
   ),
 
   bibentry(


### PR DESCRIPTION
Below are some issues I fixed in the branch `GK-work`:

- Fixed wrong package URL in `inst/CITATION`(it was for the **heplots** CRAN page instead of the **candisc** CRAN page)
- Added missing `@importFrom` to `confusion.R` for `insight::get_response()`
- Fixed wrong variable name in `R/reflect.R` example: `coef(Rohwer)` changed to `coef(Rohwer.can)`
- Removed stray `\` in `R/redundancy.R` `@seealso` tag
- Fixed typo "qauadratic" -> "quadratic" in `R/plot_discrim.R` description; also corrected `TOTO:` -> `TODO`: in a comment
